### PR TITLE
[#7][2021-12-13]용석:QueryDSL 의존성 적용 및 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### querydsl ###
+/src/main/generated
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 
 ext {
     snippetsDir = file('build/generated-snippets')
+    querydslVersion = dependencyManagement.importedProperties['querydsl.version']
 }
 
 dependencies {
@@ -34,6 +35,11 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation "com.querydsl:querydsl-jpa" // querydsl-core를 querydsl-jpa가 포함
+    implementation "com.querydsl:querydsl-collections"
+    annotationProcessor "com.querydsl:querydsl-apt:${project.querydslVersion}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.la ng.NoClassDefFoundError (javax.annotation.Generated) 발생 대응
 
     implementation 'com.auth0:java-jwt:3.16.0'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.7.0'
@@ -55,6 +61,25 @@ test {
     outputs.dir snippetsDir
     finalizedBy 'jacocoTestReport'
 }
+
+/* [QueryDSL] Start */
+def generated = 'src/main/generated'
+
+// compile시 querydsl의 Qtype 객체 생성 위치 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl의 Qtype 객체 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시, Qtype 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+/* [QueryDSL] End */
 
 /* [JaCoCo] Start */
 jacoco {


### PR DESCRIPTION
 - QueryDSL 관련 의존성 추가
   - com.querydsl:querydsl-jpa(querydsl-core 내포)
   - com.querydsl:querydsl-collections
   - com.querydsl:querydsl-apt:jpa
   - jakarta.annotation-api

 - QueryDSL의 Qtype 관련 설정
   - build : Qtype 객체 생성 위치 및 java source set 설정
   - clean : Qtype 객체 디렉토리 삭제 설정

 - .gitignore 추가(QueryDSL 관련 객체)
