### PR TITLE
[#23]댓글 목록을 포함하는 게시글 검색 API

### DIFF
--- a/src/main/java/io/example/board/controller/PostController.java
+++ b/src/main/java/io/example/board/controller/PostController.java
@@ -2,10 +2,15 @@ package io.example.board.controller;
 
 import io.example.board.domain.dto.request.PostCreateRequest;
 import io.example.board.domain.dto.request.PostUpdateRequest;
+import io.example.board.domain.dto.request.SearchPostRequest;
 import io.example.board.domain.dto.response.PostResponse;
 import io.example.board.domain.vo.login.CurrentUser;
 import io.example.board.domain.vo.login.LoginUser;
 import io.example.board.service.PostService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
@@ -14,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 
 import static io.example.board.controller.IndexController.profileUrl;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -29,6 +35,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaTypes.HAL_JSON_VALUE
 )
+@Slf4j
 public class PostController {
 
     private final PostService postService;
@@ -79,5 +86,33 @@ public class PostController {
         // TODO: 용석(2021-09-27) : [GET, DELETE /post, GET /search] link 정보 추가
         postService.delete(id, loginUser);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity search(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String content,
+            @RequestParam(required = false) String writerName,
+            @RequestParam(required = false) LocalDateTime createdAt,
+            @RequestParam(required = false) LocalDateTime updatedAt,
+            @PageableDefault(
+                    page = 0,
+                    size = 10,
+                    sort = {"createdAt"},
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                postService.searchPostWithComments(
+                        SearchPostRequest.of(
+                                title,
+                                content,
+                                writerName,
+                                createdAt,
+                                updatedAt,
+                                pageable
+                        )
+                )
+        );
     }
 }

--- a/src/main/java/io/example/board/domain/dto/request/SearchPostRequest.java
+++ b/src/main/java/io/example/board/domain/dto/request/SearchPostRequest.java
@@ -33,6 +33,23 @@ public class SearchPostRequest {
         this.writerName = writerName;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-        this.pageable = pageable;
+        this.pageable = pageNumberToIndex(pageable);
+    }
+
+    public static SearchPostRequest of(
+            String title,
+            String content,
+            String writerName,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            Pageable pageable
+    ) {
+        return new SearchPostRequest(title, content, writerName, createdAt, updatedAt, pageNumberToIndex(pageable));
+    }
+
+    private static Pageable pageNumberToIndex(Pageable pageable) {
+        return pageable.getPageNumber() != 0 ?
+                pageable.withPage(pageable.getPageNumber() - 1) :
+                pageable;
     }
 }

--- a/src/main/java/io/example/board/domain/dto/response/CommentResponse.java
+++ b/src/main/java/io/example/board/domain/dto/response/CommentResponse.java
@@ -1,0 +1,43 @@
+package io.example.board.domain.dto.response;
+
+import io.example.board.domain.rdb.post.Comment;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author : choi-ys
+ * @date : 2022/03/23 2:43 오후
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentResponse {
+    private Long id;
+    private Long postId;
+    private String content;
+    private MemberSimpleResponse writer;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public CommentResponse(Long id, Long postId, String content, MemberSimpleResponse writer, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.postId = postId;
+        this.content = content;
+        this.writer = writer;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static CommentResponse mapTo(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getPost().getId(),
+                comment.getContent(),
+                MemberSimpleResponse.mapTo(comment.getMember()),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/io/example/board/domain/dto/response/SearchPostWithCommentsResponse.java
+++ b/src/main/java/io/example/board/domain/dto/response/SearchPostWithCommentsResponse.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author : choi-ys
@@ -24,7 +25,7 @@ public class SearchPostWithCommentsResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private MemberSimpleResponse writer;
-    private List<Comment> comments;
+    private List<CommentResponse> comments;
 
     public SearchPostWithCommentsResponse(
             Post post,
@@ -38,6 +39,8 @@ public class SearchPostWithCommentsResponse {
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
         this.writer = MemberSimpleResponse.mapTo(member);
-        this.comments = comments;
+        this.comments = comments.stream()
+                .map(comment -> CommentResponse.mapTo(comment))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/io/example/board/repository/rdb/common/PageResponse.java
+++ b/src/main/java/io/example/board/repository/rdb/common/PageResponse.java
@@ -51,7 +51,7 @@ public class PageResponse<T> {
         this.embedded = embedded;
     }
 
-    public static <T> PageResponse mapTo(Page<T> page, List<T> embedded) {
+    public static <T> PageResponse mapTo(Page<T> page) {
         return new PageResponse(
                 page.getTotalPages(),
                 page.getTotalElements(),
@@ -62,7 +62,7 @@ public class PageResponse<T> {
                 page.isLast(),
                 page.hasNext(),
                 page.hasPrevious(),
-                embedded
+                page.getContent()
         );
     }
 }

--- a/src/main/java/io/example/board/service/PostService.java
+++ b/src/main/java/io/example/board/service/PostService.java
@@ -2,10 +2,11 @@ package io.example.board.service;
 
 import io.example.board.advice.exception.ResourceNotFoundException;
 import io.example.board.domain.dto.request.PostCreateRequest;
-import io.example.board.domain.dto.request.SearchPostRequest;
 import io.example.board.domain.dto.request.PostUpdateRequest;
+import io.example.board.domain.dto.request.SearchPostRequest;
 import io.example.board.domain.dto.response.PostResponse;
 import io.example.board.domain.dto.response.SearchPostResponse;
+import io.example.board.domain.dto.response.SearchPostWithCommentsResponse;
 import io.example.board.domain.dto.response.error.ErrorCode;
 import io.example.board.domain.rdb.member.Member;
 import io.example.board.domain.rdb.post.Post;
@@ -68,6 +69,11 @@ public class PostService {
 
     public PageResponse searchPost(SearchPostRequest searchPostRequest) {
         Page<SearchPostResponse> postPageBySearchParams = postRepo.findPostPageBySearchParams(searchPostRequest);
-        return PageResponse.mapTo(postPageBySearchParams, postPageBySearchParams.getContent());
+        return PageResponse.mapTo(postPageBySearchParams);
+    }
+
+    public PageResponse searchPostWithComments(SearchPostRequest searchPostRequest) {
+        Page<SearchPostWithCommentsResponse> postWithCommentsPageBySearchParams = postRepo.findPostWithCommentsPageBySearchParams(searchPostRequest);
+        return PageResponse.mapTo(postWithCommentsPageBySearchParams);
     }
 }

--- a/src/test/java/io/example/board/repository/rdb/post/PostQueryRepoImplTest.java
+++ b/src/test/java/io/example/board/repository/rdb/post/PostQueryRepoImplTest.java
@@ -127,7 +127,7 @@ class PostQueryRepoImplTest {
                     assertThat(postWithCommentsSearchResponse.getCreatedAt()).isBeforeOrEqualTo(searchPostRequest.getUpdatedAt());
                     assertTrue(
                             postWithCommentsSearchResponse.getComments().stream()
-                                    .map(comment -> comment.getPost().getId())
+                                    .map(comment -> comment.getPostId())
                                     .allMatch(Predicate.isEqual(savedPost.getId()))
                     );
                     assertEquals(postWithCommentsSearchResponse.getWriter().getId(), savedPost.getMember().getId());


### PR DESCRIPTION
 - Comment Entity를 포함한 API 응답으로 인해 발생하는 양방향 연관관계의 순환 참조 처리를 위한 CommentResponse DTO 추가
 - Client의 Page 요청 시 index는 1부터 시작 하도록 PageRequest 정보 수신 시, Page Index 처리 : SearchPostRequest.pageNumberToIndex
 - PageResponse : 상위 객체로 부터 참조 가능한 불필요 파라미터 삭제( List<T> embedded>
 - 댓글 목록을 포함하는 게시글 검색 API 및 TC 작성
 - 불필요 주석 제거 및 코드 polishing