### PR TITLE
feat(#37): 회원 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/resources-member.adoc
+++ b/src/docs/asciidoc/resources-member.adoc
@@ -14,3 +14,13 @@ operation::member-controller-test/signup[snippets='http-request,request-headers,
 
 operation::common-docs-snippet-controller-test/enum-docs[snippets='enum-response-fields-memberStatus']
 ====
+
+[[resources-get-an-member]]
+=== ** 회원 조회 : `*GET*` Member **
+[example]
+`*GET*` 요청을 사용하여 특정 회원을 조회할 수 있습니다.
+
+====
+
+operation::member-controller-test/get-an-member-test[snippets='http-request,request-headers,path-parameters,http-response,response-fields']
+====

--- a/src/docs/asciidoc/resources-member.adoc
+++ b/src/docs/asciidoc/resources-member.adoc
@@ -12,7 +12,6 @@ NOTE: Member API는 사용자 관련 API Interface를 제공 합니다.
 
 operation::member-controller-test/signup[snippets='http-request,request-headers,request-fields,http-response,response-fields,links']
 
-operation::common-docs-snippet-controller-test/enum-docs[snippets='enum-response-fields-memberStatus']
 ====
 
 [[resources-get-an-member]]
@@ -23,4 +22,6 @@ operation::common-docs-snippet-controller-test/enum-docs[snippets='enum-response
 ====
 
 operation::member-controller-test/get-an-member-test[snippets='http-request,request-headers,path-parameters,http-response,response-fields']
+
+operation::common-docs-snippet-controller-test/enum-docs[snippets='enum-response-fields-memberStatus']
 ====

--- a/src/main/java/io/example/board/controller/MemberController.java
+++ b/src/main/java/io/example/board/controller/MemberController.java
@@ -1,24 +1,25 @@
 package io.example.board.controller;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 import io.example.board.domain.dto.request.LoginRequest;
 import io.example.board.domain.dto.request.SignupRequest;
 import io.example.board.domain.dto.response.MemberSimpleResponse;
 import io.example.board.service.MemberService;
+import java.net.URI;
+import javax.validation.Valid;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
-import java.net.URI;
-
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * @author : choi-ys
@@ -26,9 +27,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  */
 @RestController
 @RequestMapping(
-        value = "member",
-        consumes = MediaType.APPLICATION_JSON_VALUE,
-        produces = MediaTypes.HAL_JSON_VALUE
+    value = "member",
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaTypes.HAL_JSON_VALUE
 )
 public class MemberController {
 
@@ -43,16 +44,22 @@ public class MemberController {
         MemberSimpleResponse memberSimpleResponse = memberService.signup(signupRequest);
 
         WebMvcLinkBuilder selfLinkBuilder = linkTo(methodOn(this.getClass())
-                .signup(signupRequest))
-                .slash(memberSimpleResponse.getId());
+            .signup(signupRequest))
+            .slash(memberSimpleResponse.getId());
 
         URI createdUri = selfLinkBuilder.toUri();
 
         EntityModel<MemberSimpleResponse> entityModel = EntityModel.of(memberSimpleResponse);
         entityModel.add(selfLinkBuilder.withSelfRel());
-        entityModel.add(linkTo(methodOn(LoginController.class).login(new LoginRequest(signupRequest.getEmail(), signupRequest.getPassword()))).withRel("login"));
+        entityModel.add(linkTo(methodOn(LoginController.class)
+            .login(new LoginRequest(signupRequest.getEmail(), signupRequest.getPassword()))).withRel("login"));
 
         // TODO: 용석(2021/09/21): Add to api docs link info
         return ResponseEntity.created(createdUri).body(entityModel);
+    }
+
+    @GetMapping("{id}")
+    public ResponseEntity getAnMember(@PathVariable(value = "id") long memberId) {
+        return ResponseEntity.ok(memberService.getAnMember(memberId));
     }
 }

--- a/src/main/java/io/example/board/domain/dto/response/MemberDetailResponse.java
+++ b/src/main/java/io/example/board/domain/dto/response/MemberDetailResponse.java
@@ -1,0 +1,49 @@
+package io.example.board.domain.dto.response;
+
+import io.example.board.domain.rdb.member.Member;
+import io.example.board.domain.rdb.member.MemberStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/09/21 3:22 오전
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberDetailResponse extends MemberSimpleResponse {
+
+    private MemberStatus memberStatus;
+
+    // * --------------------------------------------------------------
+    // * Header : 도메인 생성
+    // * @author : choi-ys
+    // * @date : 2021/09/21 3:28 오전
+    // * --------------------------------------------------------------
+    private MemberDetailResponse(
+        Long id,
+        String email,
+        String name,
+        String nickname,
+        MemberStatus memberStatus
+    ) {
+        super(id, email, name, nickname);
+        this.memberStatus = memberStatus;
+    }
+
+    // * --------------------------------------------------------------
+    // * Header : 객체 값 매핑
+    // * @author : choi-ys
+    // * @date : 2021/09/21 3:28 오전
+    // * --------------------------------------------------------------
+    public static MemberDetailResponse mapTo(Member member) {
+        return new MemberDetailResponse(
+            member.getId(),
+            member.getEmail(),
+            member.getName(),
+            member.getNickname(),
+            member.getMemberStatus()
+        );
+    }
+}

--- a/src/main/java/io/example/board/domain/rdb/member/Member.java
+++ b/src/main/java/io/example/board/domain/rdb/member/Member.java
@@ -1,17 +1,28 @@
 package io.example.board.domain.rdb.member;
 
+import static javax.persistence.FetchType.EAGER;
+
 import io.example.board.domain.rdb.base.Auditor;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-
-import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static javax.persistence.FetchType.EAGER;
 
 /**
  * @author : choi-ys
@@ -20,11 +31,11 @@ import static javax.persistence.FetchType.EAGER;
 
 @Entity
 @Table(
-        name = "member_tb",
-        uniqueConstraints = @UniqueConstraint(
-                name = "MEMBER_EMAIL_UNIQUE",
-                columnNames = "email"
-        )
+    name = "member_tb",
+    uniqueConstraints = @UniqueConstraint(
+        name = "MEMBER_EMAIL_UNIQUE",
+        columnNames = "email"
+    )
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,14 +60,17 @@ public class Member extends Auditor {
 
     @ElementCollection(fetch = EAGER)
     @CollectionTable(
-            name = "member_role_tb",
-            joinColumns = @JoinColumn(
-                    name = "member_id",
-                    foreignKey = @ForeignKey(name = "TB_MEMBER_ROLE_MEMBER_ID_FOREIGN_KEY")
-            )
+        name = "member_role_tb",
+        joinColumns = @JoinColumn(
+            name = "member_id",
+            foreignKey = @ForeignKey(name = "TB_MEMBER_ROLE_MEMBER_ID_FOREIGN_KEY")
+        )
     )
     @Enumerated(EnumType.STRING)
     private Set<MemberRole> roles = new HashSet<>();
+
+    @Column(name = "memberStatus", nullable = false, length = 30)
+    private MemberStatus memberStatus;
 
     @Column(name = "certify", nullable = false)
     private boolean certify;
@@ -74,6 +88,7 @@ public class Member extends Auditor {
         this.password = password;
         this.name = name;
         this.nickname = nickname;
+        this.memberStatus = MemberStatus.ACCEPTED_BUT_DISABLED;
         addRoles(Set.of(MemberRole.MEMBER));
     }
 
@@ -93,7 +108,7 @@ public class Member extends Auditor {
     public Set<SimpleGrantedAuthority> mapToSimpleGrantedAuthority() {
         final String rolePrefix = "ROLE_";
         return roles.stream()
-                .map(it -> new SimpleGrantedAuthority(rolePrefix + it))
-                .collect(Collectors.toSet());
+            .map(it -> new SimpleGrantedAuthority(rolePrefix + it))
+            .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/io/example/board/service/MemberService.java
+++ b/src/main/java/io/example/board/service/MemberService.java
@@ -1,6 +1,8 @@
 package io.example.board.service;
 
+import io.example.board.advice.exception.ResourceNotFoundException;
 import io.example.board.domain.dto.request.SignupRequest;
+import io.example.board.domain.dto.response.MemberDetailResponse;
 import io.example.board.domain.dto.response.MemberSimpleResponse;
 import io.example.board.domain.rdb.member.Member;
 import io.example.board.repository.rdb.member.MemberRepo;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class MemberService {
+
     private final PasswordEncoder passwordEncoder;
     private final MemberRepo memberRepo;
 
@@ -30,5 +33,10 @@ public class MemberService {
         }
         Member save = memberRepo.save(signupRequest.toEntity(passwordEncoder));
         return MemberSimpleResponse.mapTo(save);
+    }
+
+    @Transactional
+    public MemberDetailResponse getAnMember(long memberId) {
+        return MemberDetailResponse.mapTo(memberRepo.findById(memberId).orElseThrow(ResourceNotFoundException::new));
     }
 }

--- a/src/test/java/io/example/board/controller/MemberControllerTest.java
+++ b/src/test/java/io/example/board/controller/MemberControllerTest.java
@@ -1,11 +1,23 @@
 package io.example.board.controller;
 
+import static io.example.board.utils.generator.docs.MemberDocumentGenerator.generateGetAnMemberDocument;
+import static io.example.board.utils.generator.docs.MemberDocumentGenerator.generateSignupMemberDocument;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.example.board.config.test.SpringBootTestConfig;
 import io.example.board.domain.dto.request.SignupRequest;
 import io.example.board.domain.dto.response.error.ErrorCode;
 import io.example.board.domain.rdb.member.Member;
+import io.example.board.domain.vo.token.Token;
 import io.example.board.utils.generator.mock.MemberGenerator;
+import io.example.board.utils.generator.mock.TokenGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -17,11 +29,6 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static io.example.board.utils.generator.docs.MemberDocumentGenerator.generateSignupMemberDocument;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 /**
  * @author : choi-ys
  * @date : 2021/09/21 4:04 오전
@@ -29,24 +36,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTestConfig
 @AutoConfigureRestDocs
 @DisplayName("API:Member")
-@Import(MemberGenerator.class)
+@Import({MemberGenerator.class, TokenGenerator.class})
 class MemberControllerTest {
 
     private final MockMvc mockMvc;
     private final ObjectMapper objectMapper;
     private final MemberGenerator memberGenerator;
+    private final TokenGenerator tokenGenerator;
+    private final String MEMBER_URL = "/member";
 
     public MemberControllerTest(
-            MockMvc mockMvc,
-            ObjectMapper objectMapper,
-            MemberGenerator memberGenerator
+        MockMvc mockMvc,
+        ObjectMapper objectMapper,
+        MemberGenerator memberGenerator,
+        TokenGenerator tokenGenerator
     ) {
         this.mockMvc = mockMvc;
         this.objectMapper = objectMapper;
         this.memberGenerator = memberGenerator;
+        this.tokenGenerator = tokenGenerator;
     }
-
-    private final String MEMBER_URL = "/member";
 
     @Test
     @DisplayName("[200:POST]회원가입")
@@ -56,22 +65,22 @@ class MemberControllerTest {
 
         // When
         ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post(MEMBER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaTypes.HAL_JSON)
-                .content(objectMapper.writeValueAsString(signupRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaTypes.HAL_JSON)
+            .content(objectMapper.writeValueAsString(signupRequest))
         );
 
         // Then
         resultActions.andDo(print())
-                .andExpect(status().isCreated())
-                .andExpect(header().exists(HttpHeaders.LOCATION))
-                .andExpect(header().exists(HttpHeaders.CONTENT_TYPE))
-                .andExpect(jsonPath("id").exists())
-                .andExpect(jsonPath("email").value(signupRequest.getEmail()))
-                .andExpect(jsonPath("name").value(signupRequest.getName()))
-                .andExpect(jsonPath("nickname").value(signupRequest.getNickname()))
-                .andExpect(jsonPath("_links.self").exists())
-                .andDo(generateSignupMemberDocument())
+            .andExpect(status().isCreated())
+            .andExpect(header().exists(HttpHeaders.LOCATION))
+            .andExpect(header().exists(HttpHeaders.CONTENT_TYPE))
+            .andExpect(jsonPath("id").exists())
+            .andExpect(jsonPath("email").value(signupRequest.getEmail()))
+            .andExpect(jsonPath("name").value(signupRequest.getName()))
+            .andExpect(jsonPath("nickname").value(signupRequest.getNickname()))
+            .andExpect(jsonPath("_links.self").exists())
+            .andDo(generateSignupMemberDocument())
         ;
     }
 
@@ -80,17 +89,17 @@ class MemberControllerTest {
     public void signup_Fail_CauseNoArgument() throws Exception {
         // When
         ResultActions resultActions = this.mockMvc.perform(post(MEMBER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaTypes.HAL_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaTypes.HAL_JSON)
         );
 
         // Then
         resultActions.andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("method").exists())
-                .andExpect(jsonPath("path").exists())
-                .andExpect(jsonPath("code").value(ErrorCode.HTTP_MESSAGE_NOT_READABLE.name()))
-                .andExpect(jsonPath("message").value(ErrorCode.HTTP_MESSAGE_NOT_READABLE.message))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("method").exists())
+            .andExpect(jsonPath("path").exists())
+            .andExpect(jsonPath("code").value(ErrorCode.HTTP_MESSAGE_NOT_READABLE.name()))
+            .andExpect(jsonPath("message").value(ErrorCode.HTTP_MESSAGE_NOT_READABLE.message))
         ;
     }
 
@@ -102,20 +111,20 @@ class MemberControllerTest {
 
         // When
         ResultActions resultActions = this.mockMvc.perform(post(MEMBER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaTypes.HAL_JSON)
-                .content(objectMapper.writeValueAsString(signupRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaTypes.HAL_JSON)
+            .content(objectMapper.writeValueAsString(signupRequest))
         );
 
         // Then
         resultActions.andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("timestamp").exists())
-                .andExpect(jsonPath("method").exists())
-                .andExpect(jsonPath("path").exists())
-                .andExpect(jsonPath("code").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.name()))
-                .andExpect(jsonPath("message").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.message))
-                .andExpect(jsonPath("errorDetails").exists())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("timestamp").exists())
+            .andExpect(jsonPath("method").exists())
+            .andExpect(jsonPath("path").exists())
+            .andExpect(jsonPath("code").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.name()))
+            .andExpect(jsonPath("message").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.message))
+            .andExpect(jsonPath("errorDetails").exists())
         ;
     }
 
@@ -125,28 +134,28 @@ class MemberControllerTest {
         // Given
         Member savedMember = memberGenerator.savedMember();
         SignupRequest signupRequest = new SignupRequest(
-                savedMember.getEmail(),
-                savedMember.getPassword(),
-                savedMember.getName(),
-                savedMember.getNickname()
+            savedMember.getEmail(),
+            savedMember.getPassword(),
+            savedMember.getName(),
+            savedMember.getNickname()
         );
 
         // When
         ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post(MEMBER_URL)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaTypes.HAL_JSON)
-                .content(objectMapper.writeValueAsString(signupRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaTypes.HAL_JSON)
+            .content(objectMapper.writeValueAsString(signupRequest))
         );
 
         // Then
         resultActions.andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("timestamp").exists())
-                .andExpect(jsonPath("method").exists())
-                .andExpect(jsonPath("path").exists())
-                .andExpect(jsonPath("code").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.name()))
-                .andExpect(jsonPath("message").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.message))
-                .andExpect(jsonPath("errorDetails").exists())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("timestamp").exists())
+            .andExpect(jsonPath("method").exists())
+            .andExpect(jsonPath("path").exists())
+            .andExpect(jsonPath("code").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.name()))
+            .andExpect(jsonPath("message").value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.message))
+            .andExpect(jsonPath("errorDetails").exists())
         ;
     }
 
@@ -158,19 +167,68 @@ class MemberControllerTest {
 
         // When
         ResultActions resultActions = this.mockMvc.perform(post(MEMBER_URL)
-                .contentType(objectMapper.writeValueAsString(signupRequest))
-                .accept(MediaTypes.HAL_JSON)
-                .content(objectMapper.writeValueAsString(signupRequest))
+            .contentType(objectMapper.writeValueAsString(signupRequest))
+            .accept(MediaTypes.HAL_JSON)
+            .content(objectMapper.writeValueAsString(signupRequest))
         );
 
         // Then
         resultActions.andDo(print())
-                .andExpect(status().isUnsupportedMediaType())
-                .andExpect(jsonPath("timestamp").exists())
-                .andExpect(jsonPath("method").exists())
-                .andExpect(jsonPath("path").exists())
-                .andExpect(jsonPath("code").value(ErrorCode.HTTP_MEDIA_TYPE_NOT_SUPPORTED.name()))
-                .andExpect(jsonPath("message").value(ErrorCode.HTTP_MEDIA_TYPE_NOT_SUPPORTED.message))
+            .andExpect(status().isUnsupportedMediaType())
+            .andExpect(jsonPath("timestamp").exists())
+            .andExpect(jsonPath("method").exists())
+            .andExpect(jsonPath("path").exists())
+            .andExpect(jsonPath("code").value(ErrorCode.HTTP_MEDIA_TYPE_NOT_SUPPORTED.name()))
+            .andExpect(jsonPath("message").value(ErrorCode.HTTP_MEDIA_TYPE_NOT_SUPPORTED.message))
+        ;
+    }
+
+    @Test
+    @DisplayName("[200:GET]특정 회원 조회")
+    public void getAnMemberTest() throws Exception {
+        // Given
+        Member member = memberGenerator.savedMember();
+        Token token = tokenGenerator.generateToken(member);
+        final String urlTemplate = MEMBER_URL.concat("/{id}");
+//        final String urlTemplate = MEMBER_URL + "/{id}";
+
+        // When
+        ResultActions resultActions = this.mockMvc
+            .perform(RestDocumentationRequestBuilders.get(urlTemplate, member.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaTypes.HAL_JSON)
+                .header(AUTHORIZATION, TokenGenerator.getBearerToken(token.getAccessToken()))
+            );
+
+        // Then
+        resultActions.andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(member.getId()))
+            .andExpect(jsonPath("$.email").value(member.getEmail()))
+            .andExpect(jsonPath("$.name").value(member.getName()))
+            .andExpect(jsonPath("$.nickname").value(member.getNickname()))
+            .andExpect(jsonPath("$.memberStatus").value(member.getMemberStatus().getName()))
+            .andDo(generateGetAnMemberDocument())
+        ;
+    }
+
+    @Test
+    @DisplayName("[404:GET]특정 회원 조회 실패 : 존재 하지 않는 회원 조회 요청")
+    public void getAnMemberTest_Fail_CauseNotExist() throws Exception {
+        // Given
+        Token token = tokenGenerator.generateToken();
+        final String urlTemplate = MEMBER_URL.concat("/{memberId}");
+
+        // When
+        ResultActions resultActions = this.mockMvc.perform(get(urlTemplate, 0L)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaTypes.HAL_JSON)
+            .header(AUTHORIZATION, TokenGenerator.getBearerToken(token.getAccessToken()))
+        );
+
+        // Then
+        resultActions.andDo(print())
+            .andExpect(status().isNotFound())
         ;
     }
 }

--- a/src/test/java/io/example/board/service/MemberServiceTest.java
+++ b/src/test/java/io/example/board/service/MemberServiceTest.java
@@ -1,9 +1,20 @@
 package io.example.board.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import io.example.board.domain.dto.request.SignupRequest;
+import io.example.board.domain.dto.response.MemberDetailResponse;
 import io.example.board.domain.rdb.member.Member;
+import io.example.board.domain.rdb.member.MemberStatus;
 import io.example.board.repository.rdb.member.MemberRepo;
 import io.example.board.utils.generator.mock.MemberGenerator;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,11 +23,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author : choi-ys
@@ -40,7 +46,6 @@ class MemberServiceTest {
     public void signup() {
         // Given
         SignupRequest signupRequest = MemberGenerator.signupRequest();
-
         given(memberRepo.save(any(Member.class))).will(AdditionalAnswers.returnsFirstArg());
 
         // When
@@ -50,5 +55,21 @@ class MemberServiceTest {
         verify(memberRepo, times(1)).existsByEmail(any(String.class));
         verify(passwordEncoder, times(1)).encode(any(String.class));
         verify(memberRepo, times(1)).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("회원 번호로 특정 회원 조회")
+    public void getAnMemberTest() {
+        // Given
+        given(memberRepo.findById(anyLong())).willReturn(Optional.of(MemberGenerator.member()));
+
+        // When
+        MemberDetailResponse actual = memberService.getAnMember(0L);
+
+        // Then
+        verify(memberRepo).findById(anyLong());
+        assertAll(
+            () -> assertThat(actual.getMemberStatus()).isEqualTo(MemberStatus.ACCEPTED_BUT_DISABLED)
+        );
     }
 }

--- a/src/test/java/io/example/board/utils/generator/docs/MemberDocumentGenerator.java
+++ b/src/test/java/io/example/board/utils/generator/docs/MemberDocumentGenerator.java
@@ -1,13 +1,20 @@
 package io.example.board.utils.generator.docs;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-
 import static io.example.board.config.docs.ApiDocumentUtils.createDocument;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 
 /**
  * @author : choi-ys
@@ -17,32 +24,55 @@ public class MemberDocumentGenerator {
 
     public static RestDocumentationResultHandler generateSignupMemberDocument() {
         return createDocument(
-                links(
-                        linkWithRel("self").description("생성된 리소스의 link 정보"),
-                        linkWithRel("login").description("로그인 리소스의 link 정보")
-                ),
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
-                ),
-                requestFields(
-                        fieldWithPath("email").description("사용자 이메일 : 각 회원을 구분하는 식별자"),
-                        fieldWithPath("password").description("사용자 비밀번호"),
-                        fieldWithPath("name").description("사용자 이름"),
-                        fieldWithPath("nickname").description("사용자 닉네임")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.LOCATION).description("Location header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        fieldWithPath("id").description("사용자 ID"),
-                        fieldWithPath("email").description("사용자 이메일"),
-                        fieldWithPath("name").description("사용자 이름"),
-                        fieldWithPath("nickname").description("사용자 닉네임"),
-                        fieldWithPath("_links.self.href").description("생성된 리소스의 link 정보"),
-                        fieldWithPath("_links.login.href").description("로그인 리소스의 link 정보")
-                )
+            links(
+                linkWithRel("self").description("생성된 리소스의 link 정보"),
+                linkWithRel("login").description("로그인 리소스의 link 정보")
+            ),
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
+            ),
+            requestFields(
+                fieldWithPath("email").description("사용자 이메일 : 각 회원을 구분하는 식별자"),
+                fieldWithPath("password").description("사용자 비밀번호"),
+                fieldWithPath("name").description("사용자 이름"),
+                fieldWithPath("nickname").description("사용자 닉네임")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.LOCATION).description("Location header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                fieldWithPath("id").description("사용자 ID"),
+                fieldWithPath("email").description("사용자 이메일"),
+                fieldWithPath("name").description("사용자 이름"),
+                fieldWithPath("nickname").description("사용자 닉네임"),
+                fieldWithPath("_links.self.href").description("생성된 리소스의 link 정보"),
+                fieldWithPath("_links.login.href").description("로그인 리소스의 link 정보")
+            )
+        );
+    }
+
+    public static RestDocumentationResultHandler generateGetAnMemberDocument() {
+        return createDocument(
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
+                headerWithName(AUTHORIZATION).description("access token header")
+            ),
+            pathParameters(
+                parameterWithName("id").description("사용자 ID")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                fieldWithPath("id").description("사용자 ID"),
+                fieldWithPath("email").description("사용자 이메일"),
+                fieldWithPath("name").description("사용자 이름"),
+                fieldWithPath("nickname").description("사용자 닉네임"),
+                fieldWithPath("memberStatus").description("사용자 상태")
+            )
         );
     }
 }


### PR DESCRIPTION
회원 Entity에 회원 상태를 표현하는 MemberStatus 속성 추가

회원 조회 Service 구현
- 회원 번호로 회원 상세 조회를 처리하는 로직 구현
- 회원 상세 항목이 포함된 응답 객체 정의
- 회원 조회 Service TC 작성

회원 조회 Controller 구현
- GET /member/{memberId}를 Endpoint로 하는 API 작성
- 회원 조회 API TC 작성
- Spring REST Docs를 이용한 회원 조회 API Docs 작성