### PR TITLE
feat(#39): Enum으로 정의된 상태 코드 객체의 API 문서 팝업 처리

### DIFF
--- a/src/docs/asciidoc/docinfo.html
+++ b/src/docs/asciidoc/docinfo.html
@@ -1,0 +1,42 @@
+<link href="https://fonts.googleapis.com/css?family=Noto+Sans+KR&display=swap" rel="stylesheet">
+<style>
+  body {
+    font-family: 'Noto Sans KR', sans-serif;
+  }
+</style>
+<script>
+  function ready(callbackFunc) {
+    if (document.readyState !== 'loading') {
+      // Document is already ready, call the callback directly
+      callbackFunc();
+    } else if (document.addEventListener) {
+      // All modern browsers to register DOMContentLoaded
+      document.addEventListener('DOMContentLoaded', callbackFunc);
+    } else {
+      // Old IE browsers
+      document.attachEvent('onreadystatechange', function () {
+        if (document.readyState === 'complete') {
+          callbackFunc();
+        }
+      });
+    }
+  }
+
+  function openPopup(event) {
+
+    const target = event.target;
+    if (target.className !== "popup") {
+      return;
+    }
+
+    event.preventDefault();
+    const screenX = event.screenX;
+    const screenY = event.screenY;
+    window.open(target.href, target.text, `left=${screenX}, top=${screenY}, width=500, height=600, status=no, menubar=no, toolbar=no, resizable=no`);
+  }
+
+  ready(function () {
+    const el = document.getElementById("content");
+    el.addEventListener("click", event => openPopup(event), false);
+  });
+</script>

--- a/src/docs/asciidoc/enums/member-status.adoc
+++ b/src/docs/asciidoc/enums/member-status.adoc
@@ -1,0 +1,5 @@
+:doctype: book
+:icons: font
+
+[[member-status]]
+include::{snippets}/common-docs-snippet-controller-test/enum-docs/enum-response-fields-memberStatus.adoc[]

--- a/src/docs/asciidoc/overview.adoc
+++ b/src/docs/asciidoc/overview.adoc
@@ -13,7 +13,6 @@ API에 대한 전체적인 설명을 포함합니다.
 TIP: ** 본 API에서 사용하는 HTTP 동사(verbs)는 가능한 한 표준 HTTP와 REST 규약을 따릅니다. **
 
 [frame=none]
-[cols="*.>m"]
 |===
 | Http Method | Description
 

--- a/src/docs/asciidoc/resources-member.adoc
+++ b/src/docs/asciidoc/resources-member.adoc
@@ -23,5 +23,4 @@ operation::member-controller-test/signup[snippets='http-request,request-headers,
 
 operation::member-controller-test/get-an-member-test[snippets='http-request,request-headers,path-parameters,http-response,response-fields']
 
-operation::common-docs-snippet-controller-test/enum-docs[snippets='enum-response-fields-memberStatus']
 ====

--- a/src/main/java/io/example/board/config/security/endpoint/AuthenticationEndpointByRoles.java
+++ b/src/main/java/io/example/board/config/security/endpoint/AuthenticationEndpointByRoles.java
@@ -1,9 +1,8 @@
 package io.example.board.config.security.endpoint;
 
-import org.springframework.http.HttpMethod;
-
 import java.util.Arrays;
 import java.util.List;
+import org.springframework.http.HttpMethod;
 
 /**
  * @author : choi-ys
@@ -12,24 +11,24 @@ import java.util.List;
 public enum AuthenticationEndpointByRoles {
 
     NONE(Arrays.asList(
-            new AuthenticationRequest(HttpMethod.GET, Arrays.asList(
-                    "/post/**", "/index/**"
-            )),
-            new AuthenticationRequest(HttpMethod.POST, Arrays.asList(
-                    "/member",
-                    "/login"
-            ))
+        new AuthenticationRequest(HttpMethod.GET, Arrays.asList(
+            "/post/**", "/index/**", "/docs/**"
+        )),
+        new AuthenticationRequest(HttpMethod.POST, Arrays.asList(
+            "/member",
+            "/login"
+        ))
     )),
     MEMBER(Arrays.asList(
-            new AuthenticationRequest(HttpMethod.POST, Arrays.asList(
-                    "/refresh", "/post"
-            )),
-            new AuthenticationRequest(HttpMethod.PATCH, Arrays.asList(
-                    "/post"
-            )),
-            new AuthenticationRequest(HttpMethod.DELETE, Arrays.asList(
-                    "/post/**"
-            ))
+        new AuthenticationRequest(HttpMethod.POST, Arrays.asList(
+            "/refresh", "/post"
+        )),
+        new AuthenticationRequest(HttpMethod.PATCH, Arrays.asList(
+            "/post"
+        )),
+        new AuthenticationRequest(HttpMethod.DELETE, Arrays.asList(
+            "/post/**"
+        ))
     ));
 
     private List<AuthenticationRequest> matchers;
@@ -40,10 +39,10 @@ public enum AuthenticationEndpointByRoles {
 
     public String[] patterns(HttpMethod httpMethod) {
         return matchers.stream()
-                .filter(it -> it.getHttpMethod().equals(httpMethod))
-                .map(it -> it.getScope())
-                .flatMap(arr -> Arrays.stream(arr.toArray(String[]::new)))
-                .toArray(String[]::new)
-                ;
+            .filter(it -> it.getHttpMethod().equals(httpMethod))
+            .map(it -> it.getScope())
+            .flatMap(arr -> Arrays.stream(arr.toArray(String[]::new)))
+            .toArray(String[]::new)
+            ;
     }
 }

--- a/src/test/java/io/example/board/utils/generator/docs/MemberDocumentGenerator.java
+++ b/src/test/java/io/example/board/utils/generator/docs/MemberDocumentGenerator.java
@@ -1,6 +1,8 @@
 package io.example.board.utils.generator.docs;
 
 import static io.example.board.config.docs.ApiDocumentUtils.createDocument;
+import static io.example.board.utils.generator.docs.common.EnumDocumentLinkGenerator.TargetEnum.MEMBER_STATUS;
+import static io.example.board.utils.generator.docs.common.EnumDocumentLinkGenerator.enumLinkGenerator;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -71,7 +73,7 @@ public class MemberDocumentGenerator {
                 fieldWithPath("email").description("사용자 이메일"),
                 fieldWithPath("name").description("사용자 이름"),
                 fieldWithPath("nickname").description("사용자 닉네임"),
-                fieldWithPath("memberStatus").description("사용자 상태")
+                fieldWithPath("memberStatus").description(enumLinkGenerator(MEMBER_STATUS))
             )
         );
     }

--- a/src/test/java/io/example/board/utils/generator/docs/PostDocumentGenerator.java
+++ b/src/test/java/io/example/board/utils/generator/docs/PostDocumentGenerator.java
@@ -1,253 +1,225 @@
 package io.example.board.utils.generator.docs;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import static io.example.board.config.docs.ApiDocumentUtils.createDocument;
+import static io.example.board.config.docs.ApiDocumentUtils.format;
+import static io.example.board.utils.generator.docs.common.CommonFieldDescriptor.commonErrorFieldWithPath;
+import static io.example.board.utils.generator.docs.common.CommonFieldDescriptor.commonPaginationFieldWithPath;
+import static io.example.board.utils.generator.docs.common.CommonFieldDescriptor.invalidErrorFieldWithPath;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static io.example.board.config.docs.ApiDocumentUtils.createDocument;
-import static io.example.board.config.docs.ApiDocumentUtils.format;
-import static io.example.board.utils.generator.docs.common.CommonFieldDescriptor.*;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 
 /**
  * @author : choi-ys
  * @date : 2021-09-28 오전 5:40
  */
 public class PostDocumentGenerator {
+
     public static RestDocumentationResultHandler generateCreatePostDocument() {
         return createDocument(
-                links(
-                        linkWithRel("self").description("생성된 리소스의 link 정보"),
-                        linkWithRel("profile").description("API 목차 link 정보")
-                ),
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
-                        headerWithName(AUTHORIZATION).description("access token header")
-                ),
-                requestFields(
-                        fieldWithPath("title").description("게시글 제목").attributes(format("1~10자의 문자열")),
-                        fieldWithPath("content").description("게시글 본문")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.LOCATION).description("Location header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        fieldWithPath("id").description("게시글 ID"),
-                        fieldWithPath("title").description("게시글 제목"),
-                        fieldWithPath("content").description("게시글 본문"),
-                        fieldWithPath("viewCount").description("게시글 조회수"),
-                        fieldWithPath("display").description("게시글의 전시 여부"),
-                        fieldWithPath("writer.id").description("작성자 ID"),
-                        fieldWithPath("writer.email").description("작성자 이메일"),
-                        fieldWithPath("writer.name").description("작성자 이름"),
-                        fieldWithPath("writer.nickname").description("작성자 닉네임"),
-                        fieldWithPath("_links.self.href").description("생성된 리소스의 link 정보"),
-                        fieldWithPath("_links.profile.href").description("API 목차 link 정보")
-                )
+            links(
+                linkWithRel("self").description("생성된 리소스의 link 정보"),
+                linkWithRel("profile").description("API 목차 link 정보")
+            ),
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
+                headerWithName(AUTHORIZATION).description("access token header")
+            ),
+            requestFields(
+                fieldWithPath("title").description("게시글 제목").attributes(format("1~10자의 문자열")),
+                fieldWithPath("content").description("게시글 본문")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.LOCATION).description("Location header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                fieldWithPath("id").description("게시글 ID"),
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("content").description("게시글 본문"),
+                fieldWithPath("viewCount").description("게시글 조회수"),
+                fieldWithPath("display").description("게시글의 전시 여부"),
+                fieldWithPath("writer.id").description("작성자 ID"),
+                fieldWithPath("writer.email").description("작성자 이메일"),
+                fieldWithPath("writer.name").description("작성자 이름"),
+                fieldWithPath("writer.nickname").description("작성자 닉네임"),
+                fieldWithPath("_links.self.href").description("생성된 리소스의 link 정보"),
+                fieldWithPath("_links.profile.href").description("API 목차 link 정보")
+            )
         );
     }
 
     public static RestDocumentationResultHandler generateEmptyCreatePostRequestDocument() {
         return createDocument(
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
-                        headerWithName(AUTHORIZATION).description("access token header")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        commonErrorFieldWithPath()
-                )
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
+                headerWithName(AUTHORIZATION).description("access token header")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                commonErrorFieldWithPath()
+            )
         );
     }
 
     public static RestDocumentationResultHandler generateInvalidCreatePostRequestDocument() {
         return createDocument(
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
-                        headerWithName(AUTHORIZATION).description("access token header")
-                ),
-                requestFields(
-                        fieldWithPath("title").description("게시글 제목").attributes(format("1~10자의 문자열")),
-                        fieldWithPath("content").description("게시글 본문")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        Stream.concat(commonErrorFieldWithPath().stream(), invalidErrorFieldWithPath().stream())
-                                .collect(Collectors.toList())
-                )
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
+                headerWithName(AUTHORIZATION).description("access token header")
+            ),
+            requestFields(
+                fieldWithPath("title").description("게시글 제목").attributes(format("1~10자의 문자열")),
+                fieldWithPath("content").description("게시글 본문")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                Stream.concat(commonErrorFieldWithPath().stream(), invalidErrorFieldWithPath().stream())
+                    .collect(Collectors.toList())
+            )
         );
     }
 
     public static RestDocumentationResultHandler generateGetAnPostDocument() {
         return createDocument(
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
-                ),
-                pathParameters(
-                        parameterWithName("id").description("게시글 ID")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        fieldWithPath("id").description("게시글 ID"),
-                        fieldWithPath("title").description("게시글 제목"),
-                        fieldWithPath("content").description("게시글 본문"),
-                        fieldWithPath("viewCount").description("게시글 조회수"),
-                        fieldWithPath("display").description("게시글의 전시 여부"),
-                        fieldWithPath("writer.id").description("작성자 ID"),
-                        fieldWithPath("writer.email").description("작성자 이메일"),
-                        fieldWithPath("writer.name").description("작성자 이름"),
-                        fieldWithPath("writer.nickname").description("작성자 닉네임")
-                )
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
+            ),
+            pathParameters(
+                parameterWithName("id").description("게시글 ID")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                fieldWithPath("id").description("게시글 ID"),
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("content").description("게시글 본문"),
+                fieldWithPath("viewCount").description("게시글 조회수"),
+                fieldWithPath("display").description("게시글의 전시 여부"),
+                fieldWithPath("writer.id").description("작성자 ID"),
+                fieldWithPath("writer.email").description("작성자 이메일"),
+                fieldWithPath("writer.name").description("작성자 이름"),
+                fieldWithPath("writer.nickname").description("작성자 닉네임")
+            )
         );
     }
 
     public static RestDocumentationResultHandler generateUpdateAnPostDocument() {
         return createDocument(
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
-                        headerWithName(AUTHORIZATION).description("access token header")
-                ),
-                pathParameters(
-                        parameterWithName("id").description("게시글 ID")
-                ),
-                requestFields(
-                        fieldWithPath("id").description("게시글 ID"),
-                        fieldWithPath("title").description("게시글 제목"),
-                        fieldWithPath("content").description("게시글 본문"),
-                        fieldWithPath("display").description("전시 여부")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        fieldWithPath("id").description("게시글 ID"),
-                        fieldWithPath("title").description("게시글 제목"),
-                        fieldWithPath("content").description("게시글 본문"),
-                        fieldWithPath("viewCount").description("게시글 조회수"),
-                        fieldWithPath("display").description("게시글의 전시 여부"),
-                        fieldWithPath("writer.id").description("작성자 ID"),
-                        fieldWithPath("writer.email").description("작성자 이메일"),
-                        fieldWithPath("writer.name").description("작성자 이름"),
-                        fieldWithPath("writer.nickname").description("작성자 닉네임")
-                )
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
+                headerWithName(AUTHORIZATION).description("access token header")
+            ),
+            pathParameters(
+                parameterWithName("id").description("게시글 ID")
+            ),
+            requestFields(
+                fieldWithPath("id").description("게시글 ID"),
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("content").description("게시글 본문"),
+                fieldWithPath("display").description("전시 여부")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                fieldWithPath("id").description("게시글 ID"),
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("content").description("게시글 본문"),
+                fieldWithPath("viewCount").description("게시글 조회수"),
+                fieldWithPath("display").description("게시글의 전시 여부"),
+                fieldWithPath("writer.id").description("작성자 ID"),
+                fieldWithPath("writer.email").description("작성자 이메일"),
+                fieldWithPath("writer.name").description("작성자 이름"),
+                fieldWithPath("writer.nickname").description("작성자 닉네임")
+            )
         );
     }
 
     public static RestDocumentationResultHandler generateDeleteAnPostDocument() {
         return createDocument(
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
-                        headerWithName(AUTHORIZATION).description("access token header")
-                ),
-                pathParameters(
-                        parameterWithName("id").description("게시글 ID")
-                )
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header"),
+                headerWithName(AUTHORIZATION).description("access token header")
+            ),
+            pathParameters(
+                parameterWithName("id").description("게시글 ID")
+            )
         );
     }
 
     public static RestDocumentationResultHandler generateSearchPostDocument() {
         return createDocument(
-                requestHeaders(
-                        headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
-                ),
-                requestParameters(
-                        parameterWithName("title").description("게시글 제목"),
-                        parameterWithName("content").description("게시글 내용"),
-                        parameterWithName("writerName").description("게시글 작성자"),
-                        parameterWithName("page").description("요청 페이지 번호"),
-                        parameterWithName("size").description("페이지당 항목 수"),
-                        parameterWithName("sort").description("정렬 기준 : 정렬 항목 명"),
-                        parameterWithName("direction").description("정렬 기준 : 순서(ASC, DESC)")
-                ),
-                responseHeaders(
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
-                ),
-                responseFields(
-                        Stream.concat(
-                                Arrays.asList(
-                                        fieldWithPath("embedded[*].id").description("게시글 ID"),
-                                        fieldWithPath("embedded[*].title").description("게시글 제목"),
-                                        fieldWithPath("embedded[*].content").description("게시글 내용"),
-                                        fieldWithPath("embedded[*].viewCount").description("게시글 조회 수"),
-                                        fieldWithPath("embedded[*].createdAt").description("게시글 생성일"),
-                                        fieldWithPath("embedded[*].updatedAt").description("게시글 수정일"),
-                                        fieldWithPath("embedded[*].writer").description("게시글 작성자 정보"),
-                                        fieldWithPath("embedded[*].writer.id").description("게시글 작성자 ID"),
-                                        fieldWithPath("embedded[*].writer.email").description("게시글 작성자 이메일"),
-                                        fieldWithPath("embedded[*].writer.name").description("게시글 작성자 이름"),
-                                        fieldWithPath("embedded[*].writer.nickname").description("게시글 작성자 닉네임"),
-                                        fieldWithPath("embedded[*].comments").description("게시글 댓글 배열"),
-                                        fieldWithPath("embedded[*].comments[*].id").description("댓글 ID"),
-                                        fieldWithPath("embedded[*].comments[*].postId").description("댓글이 작성된 게시글 ID"),
-                                        fieldWithPath("embedded[*].comments[*].content").description("댓글 내용"),
-                                        fieldWithPath("embedded[*].comments[*].writer").description("댓글 작성자 정보"),
-                                        fieldWithPath("embedded[*].comments[*].writer.id").description("댓글 작성자 ID"),
-                                        fieldWithPath("embedded[*].comments[*].writer.email").description("댓글 작성자 이메일"),
-                                        fieldWithPath("embedded[*].comments[*].writer.name").description("댓글 작성자 이름"),
-                                        fieldWithPath("embedded[*].comments[*].writer.nickname").description("댓글 작성자 이름"),
-                                        fieldWithPath("embedded[*].comments[*].createdAt").description("댓글 생성일"),
-                                        fieldWithPath("embedded[*].comments[*].updatedAt").description("댓글 수정일")
-                                ).stream(), commonPaginationFieldWithPath().stream()
-                        ).collect(Collectors.toList())
-                )
+            requestHeaders(
+                headerWithName(HttpHeaders.ACCEPT).description("accept type header"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("content type header")
+            ),
+            requestParameters(
+                parameterWithName("title").description("게시글 제목"),
+                parameterWithName("content").description("게시글 내용"),
+                parameterWithName("writerName").description("게시글 작성자"),
+                parameterWithName("page").description("요청 페이지 번호"),
+                parameterWithName("size").description("페이지당 항목 수"),
+                parameterWithName("sort").description("정렬 기준 : 정렬 항목 명"),
+                parameterWithName("direction").description("정렬 기준 : 순서(ASC, DESC)")
+            ),
+            responseHeaders(
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Response content type")
+            ),
+            responseFields(
+                Stream.concat(
+                    Arrays.asList(
+                        fieldWithPath("embedded[*].id").description("게시글 ID"),
+                        fieldWithPath("embedded[*].title").description("게시글 제목"),
+                        fieldWithPath("embedded[*].content").description("게시글 내용"),
+                        fieldWithPath("embedded[*].viewCount").description("게시글 조회 수"),
+                        fieldWithPath("embedded[*].createdAt").description("게시글 생성일"),
+                        fieldWithPath("embedded[*].updatedAt").description("게시글 수정일"),
+                        fieldWithPath("embedded[*].writer").description("게시글 작성자 정보"),
+                        fieldWithPath("embedded[*].writer.id").description("게시글 작성자 ID"),
+                        fieldWithPath("embedded[*].writer.email").description("게시글 작성자 이메일"),
+                        fieldWithPath("embedded[*].writer.name").description("게시글 작성자 이름"),
+                        fieldWithPath("embedded[*].writer.nickname").description("게시글 작성자 닉네임"),
+                        fieldWithPath("embedded[*].comments").description("게시글 댓글 배열"),
+                        fieldWithPath("embedded[*].comments[*].id").description("댓글 ID"),
+                        fieldWithPath("embedded[*].comments[*].postId").description("댓글이 작성된 게시글 ID"),
+                        fieldWithPath("embedded[*].comments[*].content").description("댓글 내용"),
+                        fieldWithPath("embedded[*].comments[*].writer").description("댓글 작성자 정보"),
+                        fieldWithPath("embedded[*].comments[*].writer.id").description("댓글 작성자 ID"),
+                        fieldWithPath("embedded[*].comments[*].writer.email").description("댓글 작성자 이메일"),
+                        fieldWithPath("embedded[*].comments[*].writer.name").description("댓글 작성자 이름"),
+                        fieldWithPath("embedded[*].comments[*].writer.nickname").description("댓글 작성자 이름"),
+                        fieldWithPath("embedded[*].comments[*].createdAt").description("댓글 생성일"),
+                        fieldWithPath("embedded[*].comments[*].updatedAt").description("댓글 수정일")
+                    ).stream(), commonPaginationFieldWithPath().stream()
+                ).collect(Collectors.toList())
+            )
         );
     }
-
-//    private static List<FieldDescriptor> commonPaginationFieldWithPath(){
-//        return Arrays.asList(
-//                fieldWithPath("totalPages").description("전페 페이지 수"),
-//                fieldWithPath("totalElementCount").description("전체 요소 수"),
-//                fieldWithPath("currentPage").description("현제 페이지 번호"),
-//                fieldWithPath("currentElementCount").description("현재 페이지의 요수 수"),
-//                fieldWithPath("perPageNumber").description("페이지당 요소 수"),
-//                fieldWithPath("firstPage").description("첫 페이지 여부"),
-//                fieldWithPath("lastPage").description("마지막 페이지 여부"),
-//                fieldWithPath("hasNextPage").description("다음 페이지 존재 여부"),
-//                fieldWithPath("hasPrevious").description("이전 페이지 존재 여부"),
-//                fieldWithPath("embedded").description("응답 본문 배열")
-//        );
-//    }
-
-//    private static List<FieldDescriptor> commonErrorFieldWithPath() {
-//        return Arrays.asList(
-//                fieldWithPath("timestamp").description("에러 일시"),
-//                fieldWithPath("code").description("에러 뷴류 코드"),
-//                fieldWithPath("message").description("에러 메세지"),
-//                fieldWithPath("method").description("요청 HTTP Method"),
-//                fieldWithPath("path").description("요청 URL")
-//        );
-//    }
-//
-//    private static List<FieldDescriptor> invalidErrorFieldWithPath() {
-//        return Arrays.asList(
-//                fieldWithPath("errorDetails[*]").description("에러 상세 정보 배열"),
-//                fieldWithPath("errorDetails[*].object").description("에러 객체명"),
-//                fieldWithPath("errorDetails[*].field").description("에러 필드"),
-//                fieldWithPath("errorDetails[*].code").description("에러 상세 코드"),
-//                fieldWithPath("errorDetails[*].rejectMessage").description("에러 사유"),
-//                fieldWithPath("errorDetails[*].rejectedValue").description("에러 발생값")
-//        );
-//    }
 }

--- a/src/test/java/io/example/board/utils/generator/docs/common/CommonFieldDescriptor.java
+++ b/src/test/java/io/example/board/utils/generator/docs/common/CommonFieldDescriptor.java
@@ -1,11 +1,10 @@
 package io.example.board.utils.generator.docs.common;
 
-import org.springframework.restdocs.payload.FieldDescriptor;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import org.springframework.restdocs.payload.FieldDescriptor;
 
 /**
  * @author : choi-ys
@@ -15,37 +14,37 @@ public class CommonFieldDescriptor {
 
     public static List<FieldDescriptor> commonErrorFieldWithPath() {
         return Arrays.asList(
-                fieldWithPath("timestamp").description("에러 일시"),
-                fieldWithPath("code").description("에러 뷴류 코드"),
-                fieldWithPath("message").description("에러 메세지"),
-                fieldWithPath("method").description("요청 HTTP Method"),
-                fieldWithPath("path").description("요청 URL")
+            fieldWithPath("timestamp").description("에러 일시"),
+            fieldWithPath("code").description("에러 분류 코드"),
+            fieldWithPath("message").description("에러 메세지"),
+            fieldWithPath("method").description("요청 HTTP Method"),
+            fieldWithPath("path").description("요청 URL")
         );
     }
 
     public static List<FieldDescriptor> invalidErrorFieldWithPath() {
         return Arrays.asList(
-                fieldWithPath("errorDetails[*]").description("에러 상세 정보 배열"),
-                fieldWithPath("errorDetails[*].object").description("에러 객체명"),
-                fieldWithPath("errorDetails[*].field").description("에러 필드"),
-                fieldWithPath("errorDetails[*].code").description("에러 상세 코드"),
-                fieldWithPath("errorDetails[*].rejectMessage").description("에러 사유"),
-                fieldWithPath("errorDetails[*].rejectedValue").description("에러 발생값")
+            fieldWithPath("errorDetails[*]").description("에러 상세 정보 배열"),
+            fieldWithPath("errorDetails[*].object").description("에러 객체명"),
+            fieldWithPath("errorDetails[*].field").description("에러 필드"),
+            fieldWithPath("errorDetails[*].code").description("에러 상세 코드"),
+            fieldWithPath("errorDetails[*].rejectMessage").description("에러 사유"),
+            fieldWithPath("errorDetails[*].rejectedValue").description("에러 발생값")
         );
     }
 
     public static List<FieldDescriptor> commonPaginationFieldWithPath() {
         return Arrays.asList(
-                fieldWithPath("totalPages").description("전페 페이지 수"),
-                fieldWithPath("totalElementCount").description("전체 요소 수"),
-                fieldWithPath("currentPage").description("현제 페이지 번호"),
-                fieldWithPath("currentElementCount").description("현재 페이지의 요수 수"),
-                fieldWithPath("perPageNumber").description("페이지당 요소 수"),
-                fieldWithPath("firstPage").description("첫 페이지 여부"),
-                fieldWithPath("lastPage").description("마지막 페이지 여부"),
-                fieldWithPath("hasNextPage").description("다음 페이지 존재 여부"),
-                fieldWithPath("hasPrevious").description("이전 페이지 존재 여부"),
-                fieldWithPath("embedded[*]").description("응답 본문 배열")
+            fieldWithPath("totalPages").description("전페 페이지 수"),
+            fieldWithPath("totalElementCount").description("전체 요소 수"),
+            fieldWithPath("currentPage").description("현제 페이지 번호"),
+            fieldWithPath("currentElementCount").description("현재 페이지의 요수 수"),
+            fieldWithPath("perPageNumber").description("페이지당 요소 수"),
+            fieldWithPath("firstPage").description("첫 페이지 여부"),
+            fieldWithPath("lastPage").description("마지막 페이지 여부"),
+            fieldWithPath("hasNextPage").description("다음 페이지 존재 여부"),
+            fieldWithPath("hasPrevious").description("이전 페이지 존재 여부"),
+            fieldWithPath("embedded[*]").description("응답 본문 배열")
         );
     }
 }

--- a/src/test/java/io/example/board/utils/generator/docs/common/EnumDocumentLinkGenerator.java
+++ b/src/test/java/io/example/board/utils/generator/docs/common/EnumDocumentLinkGenerator.java
@@ -1,0 +1,26 @@
+package io.example.board.utils.generator.docs.common;
+
+/**
+ * @author : choi-ys
+ * @date : 2022/05/03 12:00 오후
+ */
+public class EnumDocumentLinkGenerator {
+
+    public static String enumLinkGenerator(TargetEnum targetEnum) {
+        return String
+            .format("link:enums/%s.html[%s 코드, role=\"popup\"]", targetEnum.htmlFileName, targetEnum.linkName);
+    }
+
+    public enum TargetEnum {
+        MEMBER_STATUS("member-status", "회원 상태");
+
+        private final String htmlFileName;
+        private final String linkName;
+
+        TargetEnum(String htmlFileName, String linkName) {
+            this.htmlFileName = htmlFileName;
+            this.linkName = linkName;
+        }
+    }
+
+}


### PR DESCRIPTION
adoc 파일에 html 파일을 주입할 수 있게 해주는 asciidoctor docinfo를 이용한 custom 문서 적용
- enum으로 작성된 상태 코드 객체의 문서 팝업 처리
- shared-head 속성을 이용한 custom font 적용

회원 가입 API 문서에 포함된 회원 상태 enum 객체의 문서 snippet 제거
- 회원 가입 응답 항목에 회원 상태 필드를 포함하지 않아 불필요하다고 판단하여 삭제

기타 미 사용 코드 제거